### PR TITLE
Fix VectorContinuousCallback affect! for DifferentialEquations v8

### DIFF
--- a/src/fill_sequence/fill_sequence.jl
+++ b/src/fill_sequence/fill_sequence.jl
@@ -490,7 +490,8 @@ function fill_trap_until(trap, rateinfo, cur_amount, endtime, tstruct, z_vol_tab
     condition_reached = [0]
     
     function affect!(integrator, ix)
-        condition_reached[] = ix
+        # DiffEq v8+ passes ix as Vector{Int8} flags; older versions passed a scalar index
+        condition_reached[] = isa(ix, AbstractVector) ? findfirst(!iszero, ix) : ix
         terminate!(integrator)
     end
     cb = VectorContinuousCallback(condition, affect!, 3)


### PR DESCRIPTION
## Summary

- DifferentialEquations v8 changed the `affect!` callback signature for `VectorContinuousCallback`: `ix` is now a `Vector{Int8}` of per-event flags (1 = fired, 0 = not) rather than a scalar integer index of the single event that fired.
- The `affect!` in `_compute_exact_fill` was assigning `ix` directly into `condition_reached` (a `Vector{Int64}`), causing a `MethodError: Cannot convert Vector{Int8} to Int64`.
- Fix uses `findfirst(!iszero, ix)` to extract the scalar index from the flag vector, with an `isa` guard to stay compatible with older DiffEq versions that pass a scalar.

## Test plan

- [ ] Run `fill_sequence` against the debug dataset — previously crashed, now completes successfully
- [ ] Verify `condition_reached` correctly captures event 1 (full), 2 (empty), or 3 (stagnation) in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)