### PR TITLE
Fix compute_spillfield_graph dropping isolated trap-bottom vertices

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1048,6 +1048,10 @@ function compute_spillfield_graph(spillfield::Matrix{Int8})
     # Create directed graph of connections
     g  = Graphs.SimpleDiGraph([Graphs.SimpleEdge{Int64}((e[1], e[2])) for e in edge_filt])
 
+    # Ensure all cells are present as vertices, including isolated trap bottoms
+    # surrounded by masked cells that produce no flow edges.
+    Graphs.add_vertices!(g, xmax * ymax - Graphs.nv(g))
+
     return g
 end
 


### PR DESCRIPTION
## Summary

- `compute_spillfield_graph` was filtering out self-loops (correct) but not compensating with `add_vertices!`, so isolated cells — concretely, trap bottoms entirely surrounded by masked building cells — were silently missing as vertices from the returned graph.
- Added `Graphs.add_vertices!(g, xmax * ymax - Graphs.nv(g))` before the return, exactly matching the pattern already used in the `spillregions` flowgraph construction.

## Background

`_spillfield_flow_edges!` intentionally adds self-loop edges `(n, n)` for trap-bottom and boundary-exit cells that have no inflow, so that `_determine_connected_components` can include them in watershed regions. Callers that build a final `SimpleDiGraph` are expected to strip those self-loops and then pad the vertex count. `spillregions` did this correctly; `compute_spillfield_graph` did the stripping but skipped the padding.

## Test plan

- [ ] Existing test suite passes (`Pkg.test()`)
- [ ] Manually verify on a grid with building-masked cells adjacent to a trap bottom that the returned graph vertex count equals the number of grid cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)